### PR TITLE
support growl 1.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ begin
 		gemspec.has_rdoc = false
 		gemspec.require_paths = ["lib"]
 		gemspec.add_dependency "fluentd", "~> 0.10.0"
-		gemspec.add_dependency "ruby-growl", "~> 3.0"
+		gemspec.add_dependency "ruby-growl", "~> 4.0"
 		gemspec.test_files = Dir["test/**/*.rb"]
 		gemspec.files = Dir["bin/**/*", "lib/**/*", "test/**/*.rb"] + %w[VERSION AUTHORS Rakefile]
 		gemspec.executables = []

--- a/lib/fluent/plugin/out_growl.rb
+++ b/lib/fluent/plugin/out_growl.rb
@@ -37,7 +37,11 @@ module Fluent
 			# end
 			@notifies[DEFAULT_NOTIFICATION_NAME] = { :priority => 0, :sticky => false }
 
-			@growl = Growl.new server, appname, @notifies.keys, nil, password
+			@growl = Growl.new server, appname
+			@notifies.keys.each{|name|
+				@growl.add_notification name
+			}
+			@growl.password = password
 		end
 
 		def emit(tag, es, chain)


### PR DESCRIPTION
This patch upgrades ruby-growl to 4.0 for support growl 1.3 or above.
After applying this patch, older versions are still supported.
