### PR TITLE
Support fluentd 0.12 and secret parameter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
 		gemspec.homepage = "https://github.com/takei-yuya/fluent-plugin-growl"
 		gemspec.has_rdoc = false
 		gemspec.require_paths = ["lib"]
-		gemspec.add_dependency "fluentd", "~> 0.10.0"
+		gemspec.add_dependency "fluentd", "~> 0.12.0"
 		gemspec.add_dependency "ruby-growl", "~> 4.0"
 		gemspec.test_files = Dir["test/**/*.rb"]
 		gemspec.files = Dir["bin/**/*", "lib/**/*", "test/**/*.rb"] + %w[VERSION AUTHORS Rakefile]

--- a/lib/fluent/plugin/out_growl.rb
+++ b/lib/fluent/plugin/out_growl.rb
@@ -14,7 +14,7 @@ module Fluent
 		DEFAULT_TITLE = "Fluent Notification"
 
 		config_param :server, :string, :default => DEFAULT_SERVER
-		config_param :password, :string, :default => DEFAULT_PASSWORD
+		config_param :password, :string, :default => DEFAULT_PASSWORD, :secret => true
 		config_param :appname, :string, :default => DEFAULT_APPNAME
 
 		def configure(conf)

--- a/lib/fluent/plugin/out_growl.rb
+++ b/lib/fluent/plugin/out_growl.rb
@@ -13,12 +13,12 @@ module Fluent
 		DEFAULT_NOTIFICATION_NAME = "Fluent Defalt Notification"
 		DEFAULT_TITLE = "Fluent Notification"
 
+		config_param :server, :string, :default => DEFAULT_SERVER
+		config_param :password, :string, :default => DEFAULT_PASSWORD
+		config_param :appname, :string, :default => DEFAULT_APPNAME
+
 		def configure(conf)
 			super
-
-			server = conf['server'] || DEFAULT_SERVER
-			password = conf['password'] || DEFAULT_PASSWORD
-			appname = conf['appname'] || DEFAULT_APPNAME
 
 			@notifies = {}
 			conf.elements.select{|e|
@@ -37,11 +37,11 @@ module Fluent
 			# end
 			@notifies[DEFAULT_NOTIFICATION_NAME] = { :priority => 0, :sticky => false }
 
-			@growl = Growl.new server, appname
+			@growl = Growl.new @server, @appname
 			@notifies.keys.each{|name|
 				@growl.add_notification name
 			}
-			@growl.password = password
+			@growl.password = @password
 		end
 
 		def emit(tag, es, chain)


### PR DESCRIPTION
I'm not sure why this repository depends fluentd 0.10.x.

I bumped up fluentd dependency to 0.12.x, used `config_params` and added secret parameter.

If using fluentd dose not provide this concealing feature, it will be simply ignored.
`secret parameter` (which added in password parameter) works like this:

``` log
  <match growl.**>
    type growl
    server localhost
    password xxxxxx
    appname Fluent Growl Notify
    <notify>
      name Notify
      priority 0
      sticky false
    </notify>
    <notify>
      name StickyNotify
      priority 0
      sticky true
    </notify>
  </match>
</ROOT>
```
